### PR TITLE
Unique Extension when assign Call Center to an Agent

### DIFF
--- a/src/main/java/com/livevox/challenge/app/agent/AgentRepository.java
+++ b/src/main/java/com/livevox/challenge/app/agent/AgentRepository.java
@@ -1,7 +1,14 @@
 package com.livevox.challenge.app.agent;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AgentRepository extends JpaRepository<Agent, Long> {
 
+    @Query("SELECT agent FROM Agent agent WHERE agent.callCenterId = :callCenterId AND agent.extension = :extension ")
+    Optional<Agent> findAgentByCallCenterIdAndExtension(@Param("callCenterId") final long callCenterId,
+                                                        @Param("extension") final String extension);
 }

--- a/src/main/java/com/livevox/challenge/app/agent/AgentService.java
+++ b/src/main/java/com/livevox/challenge/app/agent/AgentService.java
@@ -1,9 +1,12 @@
 package com.livevox.challenge.app.agent;
 
+import java.util.Optional;
+
 import com.livevox.challenge.app.callcenter.CallCenter;
 import com.livevox.challenge.app.callcenter.CallCenterRepository;
 import com.livevox.challenge.app.response.Constants;
 import com.livevox.challenge.app.response.exceptions.BadRequestException;
+import com.livevox.challenge.app.response.exceptions.ConflictException;
 import com.livevox.challenge.app.response.exceptions.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,11 @@ public class AgentService {
             agentRepository.findById(id).orElseThrow(() -> new NotFoundException(Constants.AGENT_NOT_FOUND_MESSAGE));
         final CallCenter callCenter = callCenterRepository.findById(callCenterId)
             .orElseThrow(() -> new BadRequestException(Constants.CALL_CENTER_NOT_FOUND_MESSAGE));
+        final Optional<Agent> duplicatedExtension =
+            agentRepository.findAgentByCallCenterIdAndExtension(callCenterId, agent.getExtension());
+        if (duplicatedExtension.isPresent()) {
+            throw new ConflictException(Constants.UNIQUE_EXTENSION_MESSAGE);
+        }
         agent.setCallCenterId(callCenterId);
         agent.setActive(true);
         agentRepository.save(agent);

--- a/src/main/java/com/livevox/challenge/app/response/Constants.java
+++ b/src/main/java/com/livevox/challenge/app/response/Constants.java
@@ -5,6 +5,7 @@ public final class Constants {
     public static final String CALL_CENTER_ID_REQUIRED_MESSAGE = "Call center id is required";
     public static final String AGENT_NOT_FOUND_MESSAGE = "Agent not found";
     public static final String CALL_CENTER_NOT_FOUND_MESSAGE = "Call center doesn't exist";
+    public static final String UNIQUE_EXTENSION_MESSAGE = "An agent with same extension is already assigned to call center";
 
     private Constants() {
         throw new UnsupportedOperationException("Utility Class");

--- a/src/main/java/com/livevox/challenge/app/response/ExceptionResolver.java
+++ b/src/main/java/com/livevox/challenge/app/response/ExceptionResolver.java
@@ -27,7 +27,7 @@ public class ExceptionResolver {
 
     @ExceptionHandler(ConflictException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
-    public HashMap<String, String> handleNoHandlerFound(final ConflictException e) {
+    public HashMap<String, String> handleConflict(final ConflictException e) {
         return getBodyFromMessage(e.getMessage());
     }
 

--- a/src/main/java/com/livevox/challenge/app/response/ExceptionResolver.java
+++ b/src/main/java/com/livevox/challenge/app/response/ExceptionResolver.java
@@ -3,6 +3,7 @@ package com.livevox.challenge.app.response;
 import java.util.HashMap;
 
 import com.livevox.challenge.app.response.exceptions.BadRequestException;
+import com.livevox.challenge.app.response.exceptions.ConflictException;
 import com.livevox.challenge.app.response.exceptions.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,6 +22,12 @@ public class ExceptionResolver {
     @ExceptionHandler(BadRequestException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public HashMap<String, String> handleBadRequest(final BadRequestException e) {
+        return getBodyFromMessage(e.getMessage());
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public HashMap<String, String> handleNoHandlerFound(final ConflictException e) {
         return getBodyFromMessage(e.getMessage());
     }
 

--- a/src/test/java/com/livevox/challenge/app/DataGenerator.java
+++ b/src/test/java/com/livevox/challenge/app/DataGenerator.java
@@ -7,4 +7,5 @@ public class DataGenerator {
     public static final String FIRST_NAME = "John";
     public static final String LAST_NAME = "Doe";
     public static final String PHONE_NUMBER = "1234";
+    public static final String EXTENSION = "1234";
 }

--- a/src/test/java/com/livevox/challenge/app/agent/AgentControllerTest.java
+++ b/src/test/java/com/livevox/challenge/app/agent/AgentControllerTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.livevox.challenge.app.DataGenerator;
 import com.livevox.challenge.app.response.Constants;
 import com.livevox.challenge.app.response.exceptions.BadRequestException;
+import com.livevox.challenge.app.response.exceptions.ConflictException;
 import com.livevox.challenge.app.response.exceptions.NotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,6 +83,17 @@ public class AgentControllerTest {
         final MockHttpServletResponse response = getResponse(ASSIGN_URL, requestBody);
 
         Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("When duplicated extension exists then Conflict")
+    void duplicatedExtension() throws Exception {
+        given(agentService.assign(DataGenerator.AGENT_ID, DataGenerator.CALL_CENTER_ID))
+            .willThrow(new ConflictException(Constants.UNIQUE_EXTENSION_MESSAGE));
+
+        final MockHttpServletResponse response = getResponse(ASSIGN_URL, requestBody);
+
+        Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 
     @Test


### PR DESCRIPTION
This PR adds validation when assigning an agent to a call center when the agent has the same extension than one that is already assigned to the call center